### PR TITLE
better error for extract_data_arcgis.py

### DIFF
--- a/.github/workflows/extract_data_arcgis.py
+++ b/.github/workflows/extract_data_arcgis.py
@@ -101,13 +101,16 @@ if __name__ == '__main__':
     obitos_ars = {}
     
     # DADOS NACIONAIS
+    (found_date, latest_date) = (False, 0)
     for entry in data['features']:
         if entry['attributes']['Data']:
             
             unix_date = entry['attributes']['Data']/1000
             frmt_date = datetime.datetime.utcfromtimestamp(unix_date).strftime("%d-%m-%Y")
+            latest_date = max(latest_date, unix_date)
             
             if frmt_date == today: # today: #change to another day to experiment
+                found_date = True
     
               #  print("In with", frmt_date)
                 
@@ -235,6 +238,9 @@ if __name__ == '__main__':
                 recuperados_arsnorte, recuperados_arscentro, recuperados_arslvt, recuperados_arsalentejo, recuperados_arsalgarve = "", "", "", "", ""
                 recuperados_acores, recuperados_madeira = "", ""
 
+    if not found_date:
+        frmt_date = datetime.datetime.utcfromtimestamp(latest_date).strftime("%d-%m-%Y")
+        raise Exception(f"Missing date {today}, latest date {frmt_date}")
                 
     # ORDENAR DADOS
     new_row = pd.DataFrame([[


### PR DESCRIPTION
if arcgis does not have data for today, raise an explicit error stating the day of today and the latest available day, instead of failing at the end because "confirmados" and others are not defined

before:
```
(venv) imini:covid19pt-data bruno$ python .github/workflows/extract_data_arcgis.py 
Traceback (most recent call last):
  File ".github/workflows/extract_data_arcgis.py", line 243, in <module>
    confirmados,
NameError: name 'confirmados' is not defined
```

now:
```
(venv) imini:covid19pt-data bruno$ python .github/workflows/extract_data_arcgis.py 
Traceback (most recent call last):
  File ".github/workflows/extract_data_arcgis.py", line 243, in <module>
    raise Exception(f"Missing date {today}, latest date {frmt_date}")
Exception: Missing date 20-09-2020, latest date 19-09-2020
```
