### PR TITLE
[WIP] Tweet com ativos e "+"

### DIFF
--- a/.github/workflows/tweet.py
+++ b/.github/workflows/tweet.py
@@ -3,22 +3,26 @@ import pandas as pd
 from datetime import datetime
 import os
 from pathlib import Path
-import tweepy 
+import tweepy
 
 link_repo = "https://github.com/dssg-pt/covid19pt-data"
-  
+
 # Login
+
+# to verify the tweet content without publishing, use
+# export TWITTER_CONSUMER_KEY=DEBUG
 consumer_key = os.environ['TWITTER_CONSUMER_KEY']
-consumer_secret = os.environ['TWITTER_CONSUMER_SECRET']
-access_token = os.environ['TWITTER_ACCESS_TOKEN']
-access_token_secret = os.environ['TWITTER_ACCESS_SECRET']
+if consumer_key != 'DEBUG':
+    consumer_secret = os.environ['TWITTER_CONSUMER_SECRET']
+    access_token = os.environ['TWITTER_ACCESS_TOKEN']
+    access_token_secret = os.environ['TWITTER_ACCESS_SECRET']
 
 def autenticar_twitter():
-    # authentication of consumer key and secret 
-    auth = tweepy.OAuthHandler(consumer_key, consumer_secret) 
-  
-    # authentication of access token and secret 
-    auth.set_access_token(access_token, access_token_secret) 
+    # authentication of consumer key and secret
+    auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
+
+    # authentication of access token and secret
+    auth.set_access_token(access_token, access_token_secret)
     try:
         api = tweepy.API(auth)
         return api
@@ -42,19 +46,15 @@ def extrair_dados_ultimo_relatorio():
     hoje=df.data_dados[-1]
     dados_extraidos["dia"] = datetime.strptime(hoje, '%d-%m-%Y %H:%M').strftime("%d %b %Y")
 
-
-    ##Número total de casos
-    dados_extraidos["total_casos"]=df.confirmados[-1]
-
-    #novos casos
+    ##Casos
+    dados_extraidos["total_casos"]=int(df.confirmados[-1])
     dados_extraidos["novos_casos"]=int(df.confirmados.diff()[-1])
     dados_extraidos["aumento_casos"]=round(dados_extraidos["novos_casos"]/dados_extraidos["total_casos"]*100,1)
 
     ##Óbitos
-    dados_extraidos["total_obitos"]=df.obitos[-1]
+    dados_extraidos["total_obitos"]=int(df.obitos[-1])
     dados_extraidos["novos_obitos"]=int(df.obitos.diff()[-1])
     dados_extraidos["aumento_obitos"]=round(dados_extraidos["novos_obitos"]/dados_extraidos["total_obitos"]*100,2)
-
 
     ##Internados
     dados_extraidos["internados"] = int(df.internados[-1])
@@ -63,9 +63,14 @@ def extrair_dados_ultimo_relatorio():
     dados_extraidos["uci"] = int(df.internados_uci[-1])
     dados_extraidos["variacao_uci"]=int(df.internados_uci.diff()[-1])
 
+    ##Ativos
+    dados_extraidos["total_ativos"]=int(df.ativos[-1])
+    dados_extraidos["novos_ativos"]=int(df.ativos.diff()[-1])
+    dados_extraidos["aumento_ativos"]=round(dados_extraidos["novos_ativos"]/dados_extraidos["total_ativos"]*100,1)
+    #Percentagem total
+    dados_extraidos["perc_ativos"] = round(df.ativos.tail(1).values[0]/df.confirmados.tail(1).values[0]*100,1)
 
     ##Recuperados
-    #novos recuperados
     dados_extraidos["total_recuperados"]=int(df.recuperados[-1])
     dados_extraidos["novos_recuperados"]=int(df.recuperados.diff()[-1])
     dados_extraidos["aumento_recuperados"]=round(dados_extraidos["novos_recuperados"]/dados_extraidos["total_recuperados"]*100,1)
@@ -81,34 +86,53 @@ def extrair_dados_ultimo_relatorio():
     dados_extraidos["novos_acores"]=int(df.confirmados_acores.diff()[-1])
     dados_extraidos["novos_madeira"]=int(df.confirmados_madeira.diff()[-1])
 
-    return dados_extraidos
 
+    for key in dados_extraidos.keys():
+        valor = dados_extraidos[key]
+        if type(valor) not in [int, float]: continue
+        dados_extraidos[key] = format(valor, ',').replace(',', ' ')
+        if key.startswith('novos_') or key.startswith('variacao_'):
+            dados_extraidos[key] = f"+{dados_extraidos[key]}" if valor > 0 else valor
+        if key.startswith('aumento_'):
+            if valor > 0:
+                dados_extraidos[key] = f"↑{dados_extraidos[key]}"
+            elif valor < 0:
+                dados_extraidos[key] = f"↓{dados_extraidos[key]}"
+
+    return dados_extraidos
 
 def compor_tweets(dados_para_tweets):
 
     # Main tweet
+    tweet_message = (
+        "🆕Dados #COVID19PT atualizados [{dia}]:\n"
+        "📍Novos casos: {novos_casos}({aumento_casos}%) | Total: {total_casos}\n"
+        "📍Novos óbitos: {novos_obitos}({aumento_obitos}%) | Total: {total_obitos}\n"
+        "📍Novos recuperados: {novos_recuperados}({aumento_recuperados}%) | Total: {total_recuperados}\n"
+        "📍Em Internamento: {internados}({variacao_internados})\n"
+        "📍Em UCI: {uci}({variacao_uci})\n"
+        "\n"
+        "👍Recuperados {perc_recuperados}% dos casos\n"
+        "[1/3]")
 
-    tweet_message = ("🆕 Dados #COVID19PT atualizados [{dia}]:\n"
-"📍Novos casos: {novos_casos}(↑{aumento_casos}%) | Total: {total_casos}\n"
-"📍Novos óbitos: {novos_obitos}(↑{aumento_obitos}%) | Total: {total_obitos} \n"
-"📍Novos recuperados: {novos_recuperados}(↑{aumento_recuperados}%) | Total: {total_recuperados} \n" 
-"📍Em Internamento: {internados}({variacao_internados})\n"
-"📍Em UCI: {uci}({variacao_uci})\n"
-"\n"
-"👍 Recuperados {perc_recuperados}% dos casos [1/3]")
+    #    "📍Novos ativos: {novos_ativos}({aumento_ativos}%) | Total: {total_ativos}\n"
+    #    "👎Ativos {perc_ativos}% dos casos\n"
 
     # Thread
-    second_tweet = "🔎 Novos casos por região: \n \
-📍 Norte: {novos_norte} \n \
-📍 Centro: {novos_centro} \n \
-📍 LVT: {novos_lvt} \n \
-📍 Alentejo: {novos_alentejo} \n \
-📍 Algarve: {novos_algarve} \n \
-📍 Açores: {novos_acores} \n \
-📍 Madeira: {novos_madeira} \n \
-[2/3]"
+    second_tweet = (
+        "🔎Novos casos por região:\n"
+        "📍Norte: {novos_norte}\n"
+        "📍Centro: {novos_centro}\n"
+        "📍LVT: {novos_lvt}\n"
+        "📍Alentejo: {novos_alentejo}\n"
+        "📍Algarve: {novos_algarve}\n"
+        "📍Açores: {novos_acores}\n"
+        "📍Madeira: {novos_madeira}\n"
+        "[2/3]")
 
-    third_tweet = "Dados nacionais, por concelho e de amostras actualizados no nosso GitHub \n [3/3] {}"
+    third_tweet = (
+        "Dados nacionais, por concelho e de amostras actualizados no nosso GitHub.\n"
+        "[3/3] {}")
 
     texto_tweet_1 = tweet_message.format(**dados_para_tweets)
     texto_tweet_2 = second_tweet.format(**dados_para_tweets)
@@ -116,17 +140,28 @@ def compor_tweets(dados_para_tweets):
 
     return texto_tweet_1, texto_tweet_2, texto_tweet_3
 
+def tweet_len(s):
+    # quick hack to kind of count emojis as 2 chars
+    # not 100% to spec
+    return sum( (2 if ord(c)>0x2100 else 1) for c in s)
 
 
 if __name__ == '__main__':
+    dados_extraidos = extrair_dados_ultimo_relatorio()
+    texto_tweet_1, texto_tweet_2, texto_tweet_3 = compor_tweets(dados_extraidos)
+
+    if consumer_key == 'DEBUG':
+        print(f"Tweet 1 {tweet_len(texto_tweet_1)} '''\n{texto_tweet_1}\n'''")
+        print(f"Tweet 2 {tweet_len(texto_tweet_2)} '''\n{texto_tweet_2}\n'''")
+        print(f"Tweet 3 {tweet_len(texto_tweet_3)} '''\n{texto_tweet_3}\n'''")
+        exit(0)
+
     api = autenticar_twitter()
     try:
-      api.me()  
+      api.me()
     except Exception as ex:
         print("Erro na autenticação. Programa vai fechar")
         exit(0)
-    dados_extraidos = extrair_dados_ultimo_relatorio()    
-    texto_tweet_1, texto_tweet_2, texto_tweet_3 = compor_tweets(dados_extraidos)
 
     # Update status and create thread
     try:
@@ -139,7 +174,3 @@ if __name__ == '__main__':
         print("Erro a enviar o tweet")
         print(e)
         pass
-    
-
-
-


### PR DESCRIPTION
Adiciona ativos ao primeiro tweet, o que força o thumbs up do recuperados para o segundo tweet.
Adiciona "+" na variação de internados e UCI, para consistência com o "-" quando está a melhorar.
Adiciona um quick hack para ver o texto e tamanho dos tweets sem precisar de saber as keys
Alinha os espaços entre o emoji e o texto

```
(venv) imini:covid19pt-data bruno$ export TWITTER_CONSUMER_KEY=DEBUG
(venv) imini:covid19pt-data bruno$ python .github/workflows/tweet.py 
Tweet 1 271'''
🆕 Dados #COVID19PT atualizados [19 Sep 2020]:
📍 Novos casos: 849(↑1.2%) | Total: 68025
📍 Novos óbitos: 5(↑0.26%) | Total: 1899 
📍 Novos recuperados: 351(↑0.8%) | Total: 45404 
📍 Novos ativos: 493(↑2.4%) | Total: 20722 

📍 Em Internamento: 497(+32)
📍 Em UCI: 64(+7)

[1/3]
'''
Tweet 2 179'''
👍 Recuperados 66.7% dos casos
👎 Ativos 30.5% dos casos

🔎 Novos casos por região:
📍 Norte: 288
📍 Centro: 66
📍 LVT: 439
📍 Alentejo: 16
📍 Algarve: 35
📍 Açores: 0
📍 Madeira: 5

[2/3]
'''
Tweet 3 126'''
Dados nacionais ou por concelho e de amostras actualizados no nosso GitHub em https://github.com/dssg-pt/covid19pt-data

[3/3]
'''

```