### PR TITLE
Suggestion to improve tweet

### DIFF
--- a/.github/workflows/tweet.py
+++ b/.github/workflows/tweet.py
@@ -106,17 +106,15 @@ def compor_tweets(dados_para_tweets):
     # Main tweet
     tweet_message = (
         "🆕Dados #COVID19PT atualizados [{dia}]:\n"
-        "📍Novos casos: {novos_casos}({aumento_casos}%) | Total: {total_casos}\n"
-        "📍Novos óbitos: {novos_obitos}({aumento_obitos}%) | Total: {total_obitos}\n"
-        "📍Novos recuperados: {novos_recuperados}({aumento_recuperados}%) | Total: {total_recuperados}\n"
-        "📍Em Internamento: {internados}({variacao_internados})\n"
-        "📍Em UCI: {uci}({variacao_uci})\n"
+        "📍Novos casos: {novos_casos} ({aumento_casos}%) | Total: {total_casos}\n"
+        "📍Novos óbitos: {novos_obitos} ({aumento_obitos}%) | Total: {total_obitos}\n"
+        "\n"
+        "📍Ativos: {total_ativos} ({novos_ativos})\n"
+        "📍Internados: {internados} ({variacao_internados})\n"
+        "📍Em UCI: {uci} ({variacao_uci})\n"
         "\n"
         "👍Recuperados {perc_recuperados}% dos casos\n"
         "[1/3]")
-
-    #    "📍Novos ativos: {novos_ativos}({aumento_ativos}%) | Total: {total_ativos}\n"
-    #    "👎Ativos {perc_ativos}% dos casos\n"
 
     # Thread
     second_tweet = (
@@ -131,7 +129,7 @@ def compor_tweets(dados_para_tweets):
         "[2/3]")
 
     third_tweet = (
-        "Dados nacionais actualizados no nosso GitHub.\n"
+        "Todos os dados no nosso GitHub.\n"
         "[3/3] {}")
 
     texto_tweet_1 = tweet_message.format(**dados_para_tweets)


### PR DESCRIPTION
- split the values that are accumulated and always growing - `confirmados`, `recuperados`, `óbitos` - from the values that are daily snapshots - `ativos`, `internados`, `uci` (and `enfermaria`) - to prevent further confusion of "why is confirmados_novos the sum of…" ;) 
- remove values for `recuperados`, keeping only the percentage at the end, to save space for the tweet to fit
- add breath spaces in between `value(other)`
- third tweet just saying "all data on github" without mentioning what or when. There are a lot more data there - population and sample code - and it should be obvious the repo is more up-to-date than a tweet.

This way we have a clear `novos casos` and `novos obitos`, two values always growing, with the percentage of growth, and the total.
But have no recuperados here. Just the percentage at the end.

Then, separated by an empty line, the three (out of four) daily snapshot values: `activos`, (from which some are) `internados`, (from which some are) `UCI`. `enfermaria` is also skipped.
**We want these three to go to zero.**

Then it keeps the thumbs up for the recuperados as a percentage.
**We want this to go to 100%.**

```
(venv) imini:covid19pt-data bruno$ python .github/workflows/tweet.py 
Tweet 1 247 '''
🆕Dados #COVID19PT atualizados [14 Nov 2020]:
📍Novos casos: +6 602 (↑3.1%) | Total: 211 266
📍Novos óbitos: +55 (↑1.66%) | Total: 3 305

📍Ativos: 85 444 (+1 412)
📍Internados: 2 798 (-1)
📍Em UCI: 413 (+25)

👍Recuperados 58.0% dos casos
[1/3]
'''
Tweet 2 135 '''
🔎Novos casos por região:
📍Norte: +4 154
📍Centro: +715
📍LVT: +1 563
📍Alentejo: +52
📍Algarve: +95
📍Açores: +18
📍Madeira: +5
[2/3]
'''
Tweet 3 79 '''
Todos os dados no nosso GitHub.
[3/3] https://github.com/dssg-pt/covid19pt-data
'''

```